### PR TITLE
Move core functions to base class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.idea/

--- a/lca_disclosures/__init__.py
+++ b/lca_disclosures/__init__.py
@@ -1,0 +1,1 @@
+from .base.exporter import BaseExporter

--- a/lca_disclosures/base/exporter.py
+++ b/lca_disclosures/base/exporter.py
@@ -1,16 +1,69 @@
 import json
 import os
 
+
 class BaseExporter(object):
 
-    def write(self):
-        
-        if isinstance(self.folder_path, str):
+    _folder_path = None
 
-            if not os.path.isdir(self.folder_path):
-                os.mkdir(self.folder_path)
+    @property
+    def folder_path(self):
+        return self._folder_path
 
-            full_efn = os.path.join(self.folder_path, self.efn)
+    @folder_path.setter
+    def folder_path(self, value):
+        if self._folder_path is not None:
+            raise AttributeError('value already set')
+        self._folder_path = value
+
+    def _prepare_efn(self):
+        """
+        Return the evaluated file name for the disclosure
+        :return:
+        """
+        raise NotImplemented
+
+    def _prepare_disclosure(self):
+        """
+        Compute the disclosure and return it as three lists and three sets of sparse matrix 3-tuples (COO)
+        :return: fg_flows, bg_flows, emissions, Af, Ad, Bf
+        """
+        raise NotImplemented
+
+    @property
+    def efn(self):
+        return self._prepare_efn()
+
+    @property
+    def data(self):
+        d_i, d_ii, d_iii, d_iv, d_v, d_vi = self._prepare_disclosure()
+
+        p = len(d_i)
+        n = len(d_ii)
+        m = len(d_iii)
+
+        # collate the data
+        data = {
+            'foreground flows': d_i,
+            'Af': {'shape': [p, p], 'data': d_iv},
+            'background flows': d_ii,
+            'Ad': {'shape': [n, p], 'data': d_v},
+            'foreground emissions': d_iii,
+            'Bf': {'shape': [m, p], 'data': d_vi}
+        }
+
+        return data
+
+    def write(self, folder_path=None):
+
+        folder_path = folder_path or self.folder_path
+
+        if folder_path is not None:
+
+            if not os.path.isdir(folder_path):
+                os.mkdir(folder_path)
+
+            full_efn = os.path.join(folder_path, self.efn)
 
         else:
             full_efn = self.efn

--- a/lca_disclosures/brightway2/exporter.py
+++ b/lca_disclosures/brightway2/exporter.py
@@ -5,7 +5,7 @@ from ..utils import matrix_to_coo, reconstruct_matrix
 
 class DisclosureExporter(BaseExporter):
 
-    def __init__(self, project_name, database_name, fu=None,folder_path=None, filename=None):
+    def __init__(self, project_name, database_name, fu=None, folder_path=None, filename=None):
 
         self.project_name = project_name
         self.database_name = database_name
@@ -13,8 +13,8 @@ class DisclosureExporter(BaseExporter):
         self.folder_path = folder_path
         self.filename = filename
 
-        self.efn = self._prepare_efn()
-        self.data = self._prepare_disclosure()
+        # self.efn = self._prepare_efn()
+        # self.data = self._prepare_disclosure()
 
     def _prepare_efn(self):
 
@@ -108,18 +108,20 @@ class DisclosureExporter(BaseExporter):
                         for i, x in enumerate(foreground)
                         ]
         
-        techno_matrix = {'data':techno_coords, 'shape':(len(technosphere),len(foreground))}
-        bio_matrix = {'data':bio_coords, 'shape':(len(biosphere),len(foreground))}
+        # techno_matrix = {'data':techno_coords, 'shape':(len(technosphere),len(foreground))}
+        # bio_matrix = {'data':bio_coords, 'shape':(len(biosphere),len(foreground))}
         
         unprocessed_foreground_matrix = {'data':foreground_coords, 'shape':(len(foreground), len(foreground))}
         processed_matrix = reconstruct_matrix(unprocessed_foreground_matrix, normalise=True,  clear_diagonal=True)
         
-      
-        
         foreground_coords = matrix_to_coo(processed_matrix)
-        foreground_matrix = {'data':foreground_coords, 'shape':(len(foreground), len(foreground))}
-        
-        
+        # foreground_matrix = {'data':foreground_coords, 'shape':(len(foreground), len(foreground))}
+
+        return foreground_names, technosphere_names, biosphere_names, foreground_coords, techno_coords, bio_coords
+
+
+
+"""
         data = {
             'foreground flows':foreground_names,
             'Af':foreground_matrix,
@@ -131,7 +133,6 @@ class DisclosureExporter(BaseExporter):
         
                     
         return data
-"""
     def write(self):
 
         if isinstance(self.filename, str):


### PR DESCRIPTION
I moved common elements into the base class, creating abstract methods for `_prepare_efn` and `_prepare_disclosure`, and creating a specification for what `_prepare_disclosure` should return, according to the article.